### PR TITLE
support for trident 24 bit encoders

### DIFF
--- a/Config.tri.h
+++ b/Config.tri.h
@@ -18,14 +18,20 @@
 #define SERIAL_SWAP                   OFF //    OFF, ON for swapped port or OFF for default port (ESP32/ESP8266 only.)        Infreq
 
 // ENCODER SUPPORT -----------------------------------------------------------------------------------------------------------------
-#define AXIS1_ENCODER                 OFF //    OFF, AB, CW_CCW, PULSE_DIR, BISS. RA/Azm Axis (A/MA) & (B/SLO.)               Option
-#define AXIS1_ENCODER_REVERSE         OFF //    OFF, ON to reverse the count direction.                                       Option
+#define AXIS1_ENCODER                BISS //    OFF, AB, CW_CCW, PULSE_DIR, BISS. RA/Azm Axis (A/MA) & (B/SLO.)               Option
+#define AXIS1_BISS_ENCODER_VARIANT  AS37_H39B_B //    AS37_H39B_B or TRI24 for trident 24 bit custom encoder                  Option
+#define AXIS1_ENCODER_TICKS_DEG 23301.689 // 22.222, n, (ticks/degree.) Encoder ticks per degree.                             Adjust
+#define AXIS1_ENCODER_REVERSE          ON //    OFF, ON to reverse the count direction.                                       Option
 #define AXIS1_ENCODER_ORIGIN            0 //      0, +/- offset so encoder count is 0 at home (for absolute encoders)         Option
 
-#define AXIS2_ENCODER                 OFF //    OFF, AB, CW_CCW, PULSE_DIR, BISS. Dec/Alt Axis (A/MA) & (B/SLO.)              Option
-#define AXIS2_ENCODER_REVERSE         OFF //    OFF, ON to reverse the count direction.                                       Option
+#define AXIS2_ENCODER                BISS //    OFF, AB, CW_CCW, PULSE_DIR, BISS. Dec/Alt Axis (A/MA) & (B/SLO.)              Option
+#define AXIS2_BISS_ENCODER_VARIANT  AS37_H39B_B //    AS37_H39B_B or TRI24 for trident 24 bit custom encoder                  Option
+#define AXIS2_ENCODER_TICKS_DEG 23301.689 // 22.222, n, (ticks/degree.) Encoder ticks per degree.                             Adjust
+#define AXIS2_ENCODER_REVERSE          ON //    OFF, ON to reverse the count direction.                                       Option
 #define AXIS2_ENCODER_ORIGIN            0 //      0, +/- offset so encoder count is 0 at home (for absolute encoders)         Option
 
+#define AS37_SINGLE_TURN
+#define AS37_CLOCK_RATE_KHZ          4000 // error rate is: ~2.0% at 500 KHz, ~0.5% @ 2000 KHz, ~0.01% at 4000KHz
 // THAT'S IT FOR USER CONFIGURATION!
 // -------------------------------------------------------------------------------
 

--- a/Config.tri24.h
+++ b/Config.tri24.h
@@ -18,14 +18,20 @@
 #define SERIAL_SWAP                   OFF //    OFF, ON for swapped port or OFF for default port (ESP32/ESP8266 only.)        Infreq
 
 // ENCODER SUPPORT -----------------------------------------------------------------------------------------------------------------
-#define AXIS1_ENCODER                 OFF //    OFF, AB, CW_CCW, PULSE_DIR, BISS. RA/Azm Axis (A/MA) & (B/SLO.)               Option
+#define AXIS1_ENCODER                BISS //    OFF, AB, CW_CCW, PULSE_DIR, BISS. RA/Azm Axis (A/MA) & (B/SLO.)               Option
+#define AXIS1_BISS_ENCODER_VARIANT  TRI24 //    AS37_H39B_B or TRI24 for trident 24 bit custom encoder                        Option
+#define AXIS1_ENCODER_TICKS_DEG 46603.378 // 22.222, n, (ticks/degree.) Encoder ticks per degree.                             Adjust
 #define AXIS1_ENCODER_REVERSE         OFF //    OFF, ON to reverse the count direction.                                       Option
 #define AXIS1_ENCODER_ORIGIN            0 //      0, +/- offset so encoder count is 0 at home (for absolute encoders)         Option
 
-#define AXIS2_ENCODER                 OFF //    OFF, AB, CW_CCW, PULSE_DIR, BISS. Dec/Alt Axis (A/MA) & (B/SLO.)              Option
+#define AXIS2_ENCODER                BISS //    OFF, AB, CW_CCW, PULSE_DIR, BISS. Dec/Alt Axis (A/MA) & (B/SLO.)              Option
+#define AXIS2_BISS_ENCODER_VARIANT  TRI24 //    AS37_H39B_B or TRI24 for trident 24 bit custom encoder                        Option
+#define AXIS1_ENCODER_TICKS_DEG 46603.378 // 22.222, n, (ticks/degree.) Encoder ticks per degree.                             Adjust
 #define AXIS2_ENCODER_REVERSE         OFF //    OFF, ON to reverse the count direction.                                       Option
 #define AXIS2_ENCODER_ORIGIN            0 //      0, +/- offset so encoder count is 0 at home (for absolute encoders)         Option
 
+#define AS37_SINGLE_TURN
+#define AS37_CLOCK_RATE_KHZ          4000 // error rate is: ~2.0% at 500 KHz, ~0.5% @ 2000 KHz, ~0.01% at 4000KHz
 // THAT'S IT FOR USER CONFIGURATION!
 // -------------------------------------------------------------------------------
 

--- a/EncoderBridge.ino
+++ b/EncoderBridge.ino
@@ -9,7 +9,7 @@
 #include "src/Common.h"
 NVS nv;
 
-#include "src/lib/encoder/as37h39bb/As37h39bb.h"
+#include "src/lib/encoder/biss/Biss.h"
 #include "src/lib/encoder/cwCcw/CwCcw.h"
 #include "src/lib/encoder/pulseDir/PulseDir.h"
 #include "src/lib/encoder/quadrature/Quadrature.h"
@@ -20,8 +20,8 @@ NVS nv;
   CwCcw encAxis1(AXIS1_ENCODER_A_PIN, AXIS1_ENCODER_B_PIN, 1);
 #elif AXIS1_ENCODER == PULSE_DIR
   PulseDir encAxis1(AXIS1_ENCODER_A_PIN, AXIS1_ENCODER_B_PIN, 1);
-#elif AXIS1_ENCODER == AS37_H39B_B
-  As37h39bb encAxis1(AXIS1_ENCODER_A_PIN, AXIS1_ENCODER_B_PIN, 1);
+#elif AXIS1_ENCODER == BISS
+  Biss encAxis1(AXIS1_ENCODER_A_PIN, AXIS1_ENCODER_B_PIN, 1);
 #elif AXIS1_ENCODER == SERIAL_BRIDGE
   SerialBridge encAxis1(1);
 #endif
@@ -32,8 +32,8 @@ NVS nv;
   CwCcw encAxis2(AXIS2_ENCODER_A_PIN, AXIS2_ENCODER_B_PIN, 2);
 #elif AXIS2_ENCODER == PULSE_DIR
   PulseDir encAxis2(AXIS2_ENCODER_A_PIN, AXIS2_ENCODER_B_PIN, 2);
-#elif AXIS2_ENCODER == AS37_H39B_B
-  As37h39bb encAxis2(AXIS2_ENCODER_A_PIN, AXIS2_ENCODER_B_PIN, 2);
+#elif AXIS2_ENCODER == BISS
+  Biss encAxis2(AXIS2_ENCODER_A_PIN, AXIS2_ENCODER_B_PIN, 2);
 #elif AXIS2_ENCODER == SERIAL_BRIDGE
   SerialBridge encAxis2(2);
 #endif

--- a/src/lib/Constants.h
+++ b/src/lib/Constants.h
@@ -81,7 +81,7 @@
 #define CW_CCW                      3      // clockwise/counter-clockwise encoder
 #define PULSE_DIR                   4      // pulse/direction encoder
 #define PULSE_ONLY                  5      // pulse only encoder
-#define AS37_H39B_B                 6      // Broadcom AS37-H39B-B BISS-C interface encoder
+#define BISS                        6      // Broadcom AS37-H39B-B BISS-C interface encoder
 #define SERIAL_BRIDGE               7      // serial bridge to encoders
 #define ENC_LAST                    7
 

--- a/src/lib/axis/motor/servo/Servo.h
+++ b/src/lib/axis/motor/servo/Servo.h
@@ -5,7 +5,7 @@
 
 #ifdef SERVO_MOTOR_PRESENT
 
-#include "../../../encoder/as37h39bb/As37h39bb.h"
+#include "../../../encoder/biss/Biss.h"
 #include "../../../encoder/cwCcw/CwCcw.h"
 #include "../../../encoder/pulseDir/PulseDir.h"
 #include "../../../encoder/pulseOnly/PulseOnly.h"

--- a/src/lib/encoder/biss/Biss.h
+++ b/src/lib/encoder/biss/Biss.h
@@ -3,9 +3,9 @@
 
 #include "../Encoder.h"
 
-#if AXIS1_ENCODER == AS37_H39B_B || AXIS2_ENCODER == AS37_H39B_B || AXIS3_ENCODER == AS37_H39B_B || \
-    AXIS4_ENCODER == AS37_H39B_B || AXIS5_ENCODER == AS37_H39B_B || AXIS6_ENCODER == AS37_H39B_B || \
-    AXIS7_ENCODER == AS37_H39B_B || AXIS8_ENCODER == AS37_H39B_B || AXIS9_ENCODER == AS37_H39B_B
+#if AXIS1_ENCODER == BISS || AXIS2_ENCODER == BISS || AXIS3_ENCODER == BISS || \
+    AXIS4_ENCODER == BISS || AXIS5_ENCODER == BISS || AXIS6_ENCODER == BISS || \
+    AXIS7_ENCODER == BISS || AXIS8_ENCODER == BISS || AXIS9_ENCODER == BISS
 
   // designed according protocol description found in as38-H39e-b-an100.pdf
 
@@ -14,11 +14,11 @@
     #define AS37_CLOCK_RATE_KHZ 250
   #endif
 
-  class As37h39bb : public Encoder {
+  class Biss : public Encoder {
     public:
-      // initialize AS37H39BB encoder
+      // initialize BISS encoder
       // nvAddress holds settings for the 9 supported axes, 9*4 = 72 bytes; set nvAddress 0 to disable
-      As37h39bb(int16_t maPin, int16_t sloPin, int16_t axis);
+      Biss(int16_t maPin, int16_t sloPin, int16_t axis);
 
       // get device ready for use
       void init();


### PR DESCRIPTION
Hello Howard,
To make it easier to build for my 24bit trident I added the code from the JTW code tree to be able to support both 23 and 24 bit encoders. I made this refactor for The Smartwebserver also but I'd rather you validate this before I submit the other PRs.
The code compiles but I have not had the chance to go to my observatory to test it. 

Changes:
refactored AS37 encoder support to make it more generic (BiSS) and added support for the Trident's custom 24 bit encoders